### PR TITLE
Add sorting and filtering to the victims API end-point 

### DIFF
--- a/app/Http/Controllers/Victims.php
+++ b/app/Http/Controllers/Victims.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\VictimResource;
+use App\Models\Victim;
+use Illuminate\Http\Request;
+use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class Victims extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request)
+    {
+        $per_page = 50;
+
+        if (!empty($request->get('per_page'))) {
+            $per_page = $request->get('per_page');
+        }
+
+        $victimsQuery = QueryBuilder::for(Victim::class)
+            ->allowedFilters([
+                AllowedFilter::exact('status'),
+                AllowedFilter::exact('gender')
+            ])
+            ->allowedSorts(
+                'name',
+                'security_organ_id',
+                'holding_location_id',
+                'status_date')->paginate($per_page)
+                ->appends(request()->query());
+
+        return VictimResource::collection($victimsQuery);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",
         "livewire/livewire": "^3.0",
-        "spatie/laravel-backup": "^9.0"
+        "spatie/laravel-backup": "^9.0",
+        "spatie/laravel-query-builder": "^6.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a25bb6c20abe51b35bdaa4efdc97ccf0",
+    "content-hash": "a56ed8327cc94e384efbed325a268e69",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -5715,6 +5715,80 @@
                 }
             ],
             "time": "2024-03-20T07:29:11+00:00"
+        },
+        {
+            "name": "spatie/laravel-query-builder",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-query-builder.git",
+                "reference": "69a6fd38c1515e42aec0df10d8adb8465f2f1f79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-query-builder/zipball/69a6fd38c1515e42aec0df10d8adb8465f2f1f79",
+                "reference": "69a6fd38c1515e42aec0df10d8adb8465f2f1f79",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^10.0|^11.0",
+                "illuminate/http": "^10.0|^11.0",
+                "illuminate/support": "^10.0|^11.0",
+                "php": "^8.2",
+                "spatie/laravel-package-tools": "^1.11"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "mockery/mockery": "^1.4",
+                "nunomaduro/larastan": "^2.0",
+                "orchestra/testbench": "^7.0|^8.0",
+                "pestphp/pest": "^2.0",
+                "phpunit/phpunit": "^10.0",
+                "spatie/invade": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\QueryBuilder\\QueryBuilderServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\QueryBuilder\\": "src",
+                    "Spatie\\QueryBuilder\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily build Eloquent queries from API requests",
+            "homepage": "https://github.com/spatie/laravel-query-builder",
+            "keywords": [
+                "laravel-query-builder",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-query-builder/issues",
+                "source": "https://github.com/spatie/laravel-query-builder"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2024-05-21T12:12:10+00:00"
         },
         {
             "name": "spatie/laravel-signal-aware-command",

--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -1,0 +1,63 @@
+<?php
+
+return [
+
+    /*
+     * By default the package will use the `include`, `filter`, `sort`
+     * and `fields` query parameters as described in the readme.
+     *
+     * You can customize these query string parameters here.
+     */
+    'parameters' => [
+        'include' => 'include',
+
+        'filter' => 'filter',
+
+        'sort' => 'sort',
+
+        'fields' => 'fields',
+
+        'append' => 'append',
+    ],
+
+    /*
+     * Related model counts are included using the relationship name suffixed with this string.
+     * For example: GET /users?include=postsCount
+     */
+    'count_suffix' => 'Count',
+
+    /*
+     * Related model exists are included using the relationship name suffixed with this string.
+     * For example: GET /users?include=postsExists
+     */
+    'exists_suffix' => 'Exists',
+
+    /*
+     * By default the package will throw an `InvalidFilterQuery` exception when a filter in the
+     * URL is not allowed in the `allowedFilters()` method.
+     */
+    'disable_invalid_filter_query_exception' => false,
+
+    /*
+     * By default the package will throw an `InvalidSortQuery` exception when a sort in the
+     * URL is not allowed in the `allowedSorts()` method.
+     */
+    'disable_invalid_sort_query_exception' => false,
+
+    /*
+     * By default the package will throw an `InvalidIncludeQuery` exception when an include in the
+     * URL is not allowed in the `allowedIncludes()` method.
+     */
+    'disable_invalid_includes_query_exception' => false,
+
+    /*
+     * By default, the package expects relationship names to be snake case plural when using fields[relationship].
+     * For example, fetching the id and name for a userOwner relation would look like this:
+     * GET /users?fields[user_owner]=id,name
+     *
+     * Set this to `false` if you don't want that and keep the requested relationship names as-is and allows you to
+     * request the fields using a camelCase relationship name:
+     * GET /users?fields[userOwner]=id,name
+     */
+    'convert_relation_names_to_snake_case_plural' => true,
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,10 +2,10 @@
 
 use App\Enums\Gender;
 use App\Enums\Status;
+use App\Http\Controllers\Victims;
 use App\Http\Controllers\VictimStatistics;
 use App\Http\Resources\HoldingLocationResource;
 use App\Http\Resources\SecurityOrganResource;
-use App\Http\Resources\VictimResource;
 use App\Models\HoldingLocation;
 use App\Models\SecurityOrgan;
 use Illuminate\Http\Request;
@@ -15,9 +15,7 @@ Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
 
-Route::get('/victims', function (Request $request) {
-    return VictimResource::collection(App\Models\Victim::paginate());
-});
+Route::get('/victims', Victims::class);
 
 Route::get('/gender', function (Request $request) {
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::redirect('/', '/login');
+Route::redirect('/', '/admin');
 
 Route::middleware([
     'auth:sanctum',


### PR DESCRIPTION
API rules are https://github.com/wkambale/missingpersons/issues/103

1. Added Spatie Query Builder package to ease the process of building the query strings
2. Moved the Victims API from a closure to a Controller class for better control 
3. Redirected all logins to the Filament dashboard login to reduce confusion 